### PR TITLE
Rangeshifter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This includes the Geant4 10.03.p03 install along with various other useful softw
 ## Usage
 
 ### File preparation
-First export the relevant dicom files from the TPS to new folder.
+First export the relevant dicom files from the TPS to an empty folder.
 You will need the plan file, the structure set, the plan dose and all CT images. 
 All CT files must be placed in a subdirectory called "ct".
 
 In the simulation directory, ```python run.py``` will prompt for the directory containing
 your exported dicom files and generate a new directory containing all files required for 
-a Gate simulation. Individual mac files will be generated separately for each field in
+a Gate simulation (found in data/simulationfiles). Individual mac files will be generated separately for each field in
 the plan.
 
 If running on a cluster you can split a simulation: ```jobsplitter.split_by_primaries(field.mac, N)``` 
@@ -49,8 +49,10 @@ into the TPS for comparison.
 ## Limitations / known bugs
 Many. I only recommend that you use the code to generate the Gate simulation files.
 
+All testing has been done using pencil beam scanning proton plans created in the Eclipse treatment planning system (versions 13.7 and 15.5).
+
 The header information in the mhd output from Gate will not match that of the CT image (due to
-the rotations we applied in gate in setting up the patient). You must manually correct this by changing
+any rotations applied in Gate when setting up the patient). You must manually correct this by changing
 the TransformMatrix field to match that of the CT.
 
 When simulating certain patient positions (HFP for example) Gate will also produce the wrong Origin in the

--- a/data/templates/GateMaterials.db
+++ b/data/templates/GateMaterials.db
@@ -48,6 +48,11 @@ Bismuth:    S= Bi  ; Z= 83. ; A= 208.98  g/mole
 Uranium:    S= U   ; Z= 92. ; A= 238.03  g/mole
 
 [Materials]
+LexanPolycarbonate: d=1.21 g/cm3; n=3; state=solid
+        +el: name=Hydrogen;   n=14
+        +el: name=Carbon;     n=16
+        +el: name=Oxygen;     n=3
+
 Vacuum: d=0.000001 mg/cm3 ; n=1 
 	+el: name=Hydrogen ; n=1
 

--- a/data/templates/TEMPLATE_simulateField.txt
+++ b/data/templates/TEMPLATE_simulateField.txt
@@ -77,7 +77,7 @@
 /gate/rangeshifter/placement/setRotationAxis         0 0 1
 /gate/rangeshifter/placement/setRotationAngle        0 deg
 /gate/rangeshifter/placement/setTranslation         0 0 0 mm   
-/gate/rangeshifter/setMaterial                 Water
+/gate/rangeshifter/setMaterial                 LexanPolycarbonate
 /gate/rangeshifter/vis/setVisible              1
 /gate/rangeshifter/vis/setColor                blue
 

--- a/data/templates/TEMPLATE_simulateField.txt
+++ b/data/templates/TEMPLATE_simulateField.txt
@@ -52,8 +52,8 @@
 /gate/HounsfieldMaterialGenerator/Generate
 
 # Create parameterized phantom object
-/gate/GlobalVolume/daughters/name                      patient
-/gate/GlobalVolume/daughters/insert                    ImageNestedParametrisedVolume
+/gate/GlobalVol/daughters/name                      patient
+/gate/GlobalVol/daughters/insert                    ImageNestedParametrisedVolume
 /gate/geometry/setMaterialDatabase              data/patient-HUmaterials.db
 /gate/patient/geometry/setHUToMaterialFile      data/patient-HU2mat.txt
 

--- a/data/templates/TEMPLATE_simulateField.txt
+++ b/data/templates/TEMPLATE_simulateField.txt
@@ -71,9 +71,9 @@
 /gate/GlobalVol/daughters/name                     rangeshifter
 /gate/GlobalVol/daughters/insert                   box
 
-/gate/rangeshifter/geometry/setXLength         20 cm        
-/gate/rangeshifter/geometry/setYLength         0 cm       
-/gate/rangeshifter/geometry/setZLength         20 cm         
+/gate/rangeshifter/geometry/setXLength         200 mm        
+/gate/rangeshifter/geometry/setYLength         0 mm       
+/gate/rangeshifter/geometry/setZLength         200 mm         
 /gate/rangeshifter/placement/setRotationAxis         0 0 1
 /gate/rangeshifter/placement/setRotationAngle        0 deg
 /gate/rangeshifter/placement/setTranslation         0 0 0 mm   

--- a/data/templates/z_TEMPLATE_simulateField_noMergedVolume.txt
+++ b/data/templates/z_TEMPLATE_simulateField_noMergedVolume.txt
@@ -17,87 +17,37 @@
 
 /gate/geometry/setMaterialDatabase data/GateMaterials.db
 
-
-### World
+# World
 /gate/world/geometry/setXLength 2 m
 /gate/world/geometry/setYLength 2 m
 /gate/world/geometry/setZLength 2 m
 /gate/world/setMaterial Air
 
 
-
-### Container volume for MergedVolumeActor for inclusion of rangeshifters
-/gate/world/daughters/name GlobalVol
-/gate/world/daughters/insert box
-/gate/GlobalVol/geometry/setXLength 1.5 m
-/gate/GlobalVol/geometry/setYLength 1.5 m
-/gate/GlobalVol/geometry/setZLength 1.5 m
-/gate/GlobalVol/placement/setTranslation 0.0 0.0 0.0 mm
-/gate/GlobalVol/placement/setRotationAxis 1 0 0
-/gate/GlobalVol/placement/setRotationAngle 0 deg
-/gate/GlobalVol/setMaterial Air
-/gate/GlobalVol/vis/setColor cyan
-/gate/GlobalVol/describe
-
-
-
-### Voxelized phantom added to the GlobalVol container
-
 # Generate materials from Hounsfield units
 /gate/HounsfieldMaterialGenerator/SetMaterialTable data/UCLH2019MaterialsTable_v1.txt
 /gate/HounsfieldMaterialGenerator/SetDensityTable  data/UCLH2019DensitiesTable_v1.txt
+
 /gate/HounsfieldMaterialGenerator/SetDensityTolerance               0.1 g/cm3
 /gate/HounsfieldMaterialGenerator/SetOutputMaterialDatabaseFilename data/patient-HUmaterials.db
 /gate/HounsfieldMaterialGenerator/SetOutputHUMaterialFilename       data/patient-HU2mat.txt
 /gate/HounsfieldMaterialGenerator/Generate
 
+#########################################################
 # Create parameterized phantom object
-/gate/GlobalVolume/daughters/name                      patient
-/gate/GlobalVolume/daughters/insert                    ImageNestedParametrisedVolume
+/gate/world/daughters/name                      patient
+/gate/world/daughters/insert                    ImageNestedParametrisedVolume
 /gate/geometry/setMaterialDatabase              data/patient-HUmaterials.db
 /gate/patient/geometry/setHUToMaterialFile      data/patient-HU2mat.txt
 
-# Position patient 
+
 /gate/patient/geometry/setImage                data/XXXX
+
+
+# PATIENT SUPPORT ANGLE NOT WORKING!?
 /gate/patient/placement/setRotationAxis         0 1 0
 /gate/patient/placement/setRotationAngle        XX deg
 /gate/patient/placement/setTranslation XX XX XX mm  
-
-
-
-
-
-### Rangeshifter added GlobalVol also
-/gate/GlobalVol/daughters/name                     rangeshifter
-/gate/GlobalVol/daughters/insert                   box
-
-/gate/rangeshifter/geometry/setXLength         20 cm        
-/gate/rangeshifter/geometry/setYLength         0 cm       
-/gate/rangeshifter/geometry/setZLength         20 cm         
-/gate/rangeshifter/placement/setRotationAxis         0 0 1
-/gate/rangeshifter/placement/setRotationAngle        0 deg
-/gate/rangeshifter/placement/setTranslation         0 0 0 mm   
-/gate/rangeshifter/setMaterial                 Water
-/gate/rangeshifter/vis/setVisible              1
-/gate/rangeshifter/vis/setColor                blue
-
-
-
-
-
-### MergedVolumeActor must be the FIRST actor declared
-/gate/actor/addActor MergedVolumeActor mergedVol
-/gate/actor/mergedVol/attachTo GlobalVol
-/gate/actor/mergedVol/volumeToMerge rangeshifter
-
-
-
-
-
-
-
-
-
 
 #=====================================================
 # PHYSICS

--- a/gate-pbt/simulation/generatefiles.py
+++ b/gate-pbt/simulation/generatefiles.py
@@ -372,7 +372,7 @@ def generate_files(ct_files, plan_file, dose_files, TEMPLATE_MAC, TEMPLATE_SOURC
                        setVoxelSize=dose_vox_dims,
                        setImage=ct_mhd,
                        rangeshift_rot=rs.rotation,
-                       rangeshift_tran=rs.translation,
+                       rangeshift_trans=rs.translation,
                        rangeshift_thick=rs.thickness
                       )
  

--- a/gate-pbt/simulation/generatefiles.py
+++ b/gate-pbt/simulation/generatefiles.py
@@ -324,17 +324,22 @@ def write_mac_file(template, output, planDescription, sourceDescription,
 
 
 def field_has_rangeshifter( field ):
-    """Return tru if field has rangeshifter"""
+    """Return true if field has rangeshifter"""
     return hasattr(field.IonControlPointSequence[0],"RangeShifterSettingsSequence")
 
 
 def get_source_offset(field, rs):
-    """Offset source to allow rangeshifter"""
+    """Offset source to allow rangeshifter in beam path"""
     source_offset = 0
     if field_has_rangeshifter(field):
         # offset source by thickness, rangeshifter offset from nozzle exit
         # and some arbitrary distance so source is not in rangeshifter
-        source_offset = rs.thickness + rs.offset + 5  
+        #####source_offset = rs.thickness + rs.offset + 5  
+        rsss = field.IonControlPointSequence[0].RangeShifterSettingsSequence[0]
+        snout_pos = field.IonControlPointSequence[0].SnoutPosition
+        rs_inset = rsss.IsocenterToRangeShifterDistance - snout_pos
+        source_offset = rs_inset + rs.thickness + 5
+        print("source_offset = {}".format(source_offset))
     return source_offset
 
 
@@ -357,7 +362,7 @@ def generate_files(ct_files, plan_file, dose_files, TEMPLATE_MAC, TEMPLATE_SOURC
         # Rangeshifter object
         rs = rangeshifter.get_props( field )  
         
-        # Offset to source positon (snout position) to allow rangeshifter
+        # Offset to source positon (snout position) needed to allow rangeshifter
         source_offset = get_source_offset(field, rs)
         
         

--- a/gate-pbt/simulation/overrides.py
+++ b/gate-pbt/simulation/overrides.py
@@ -23,7 +23,7 @@ HU_AIR = -1000
 ########################
 
 
-def get_external_name( structure_file ):          ## TODO: MAKE THIS MORE ROBUST; WHAT WILL OUR NAMING CONVENTION BE?
+'''def get_external_name( structure_file ):          ## TODO: MAKE THIS MORE ROBUST; WHAT WILL OUR NAMING CONVENTION BE?
     """Get contour name (BODY or EXTERNAL) """
     contour = ""
     ds = pydicom.dcmread( structure_file )
@@ -37,6 +37,24 @@ def get_external_name( structure_file ):          ## TODO: MAKE THIS MORE ROBUST
     elif "BODY" in rois:
         contour = "BODY"
     
+    return contour'''
+
+
+
+def get_external_name( structure_file ):
+    """Get contour name of external patient contour"""
+    contour = ""
+    contains_bolus = False
+    ss = pydicom.dcmread( structure_file )    
+    for struct in ss.RTROIObservationsSequence:
+        if struct.RTROIInterpretedType.lower() == "external":
+            contour = struct.ROIObservationLabel
+            print("Found external: {}".format(contour))
+        elif struct.RTROIInterpretedType.lower() == "bolus":
+            print("\n\nWARNING: Bolus found. It will be overriden with air.\n")
+    if contour=="":
+        raise Exception("No external structure found. Exiting.")
+        sys.exit(1)
     return contour
 
 

--- a/gate-pbt/simulation/overrides.py
+++ b/gate-pbt/simulation/overrides.py
@@ -23,23 +23,7 @@ HU_AIR = -1000
 ########################
 
 
-'''def get_external_name( structure_file ):          ## TODO: MAKE THIS MORE ROBUST; WHAT WILL OUR NAMING CONVENTION BE?
-    """Get contour name (BODY or EXTERNAL) """
-    contour = ""
-    ds = pydicom.dcmread( structure_file )
-    rois = rt.list_roinames( ds )
-    if "EXTERNAL" not in rois and "EXT" not in rois and "BODY" not in rois:
-        print( "\n ERROR: Structure set does not contain EXTERNAL, EXT or BODY\n")
-    elif "EXTERNAL" in rois:
-        contour = "EXTERNAL"
-    elif "EXT" in rois:
-        contour = "EXT"
-    elif "BODY" in rois:
-        contour = "BODY"
     
-    return contour'''
-
-
 
 def get_external_name( structure_file ):
     """Get contour name of external patient contour"""

--- a/gate-pbt/simulation/rangeshifter.py
+++ b/gate-pbt/simulation/rangeshifter.py
@@ -16,7 +16,8 @@ from math import sin, cos, degrees, radians
 # 3. Need exact RS dimensions
 # 4. Need RS material composition
 # 5. Need  offset RS offset from nozzle exit
-#
+# 6.  field.RangeShifterSettingsSequence[0].RangeShifterWaterEquivalentThickness or field.RangeShifterSequence??
+#        field.NumberOfRangeShifters
 #############
 
 
@@ -27,8 +28,8 @@ NOZZLE_OFFSET = 18.0  # mm
 class Rangeshifter:
     
     def __init__(self, rotation=0, translation=None, thickness=0 ):
-        self.rotation = rot
-        self.thickness = thicknesss 
+        self.rotation = rotation
+        self.thickness = thickness 
         if translation is None: 
             translation = [0,0,0]
         self.translation = translation
@@ -38,7 +39,7 @@ class Rangeshifter:
 def get_translation( field, thick, gantryangle ):
     
     #Distance (mm) from isocentre to downstream side of snout
-    snout = field.SnoutPosition  
+    snout = field.IonControlPointSequence[0].SnoutPosition  
     shift = snout + 0.5*thick + NOZZLE_OFFSET
     
     d_x = shift * sin( radians(gantryangle) )
@@ -46,7 +47,7 @@ def get_translation( field, thick, gantryangle ):
     
     translation = [d_x, d_y, 0]
     return translation
-    
+    s
 
 
 def get_props( field ):
@@ -54,15 +55,18 @@ def get_props( field ):
     (i.e. IonBeamSequence[i])
     """
     
-    has_RS = hasattr( field, "RangeShifterSettingsSequence" )
+    has_RS = hasattr( field.IonControlPointSequence[0], "RangeShifterSettingsSequence" )
+    ##has_RS_2 = hasattr( field, "RangeShifterSequence" )
     
     # Default zero rangeshifter
-    rs = RangeShifter()
+    rs = Rangeshifter()
     
-    if has_RS:       
+    ##if has_RS or has_RS_2:       
+    if has_RS:
         # Get properties
-        thick = field.RangeShifterSettingsSequence[0].RangeShifterWaterEquivalentThickness
-        gantryangle = field.GantryAngle
+        #thick = field.RangeShifterSettingsSequence[0].RangeShifterWaterEquivalentThickness
+        thick = 5.0
+        gantryangle = field.IonControlPointSequence[0].GantryAngle
         trans = get_translation(field, thick, gantryangle)
         
         print("RS props: {},{},{}".format(gantryangle, trans, thick)   )

--- a/gate-pbt/simulation/rangeshifter.py
+++ b/gate-pbt/simulation/rangeshifter.py
@@ -1,13 +1,20 @@
 # -*- coding: utf-8 -*-
 """
 Created on Thu May  7 16:25:22 2020
-
-Methods related to positioning of rangeshifter
-
 @author: SCOURT01
+
+
+Methods related to positioning of rangeshifter.
+
+Gate simulates the beam from the nozzle exit. Hence if a rangeshifter is
+in place we must first position this correctly wrt the patient and then
+offset the beam so that it passes through the rangeshifter. (The number to
+offset is the nozzle to exit distance in the source description file).
+
 """
 
-from math import sin, cos, degrees, radians
+from math import sin, cos, radians
+
 
 ######### TODO
 #
@@ -18,11 +25,16 @@ from math import sin, cos, degrees, radians
 # 5. Need  offset RS offset from nozzle exit
 # 6.  field.RangeShifterSettingsSequence[0].RangeShifterWaterEquivalentThickness or field.RangeShifterSequence??
 #        field.NumberOfRangeShifters
-#############
+#
+#########
 
 
 
-NOZZLE_OFFSET = 0  # mm
+# dist (mm) between rangeshifter distal face and nozzle exit
+RS_OFFSET = 18  
+# dictionary of rangeshifter thicknesses in use
+#RS_THICKNESS = {}
+
 
 
 class Rangeshifter:
@@ -33,6 +45,7 @@ class Rangeshifter:
         if translation is None: 
             translation = [0,0,0]
         self.translation = translation
+        self.offset = RS_OFFSET
 
 
 
@@ -40,7 +53,7 @@ def get_translation( field, thick, gantryangle ):
     
     #Distance (mm) from isocentre to downstream side of snout
     snout = field.IonControlPointSequence[0].SnoutPosition  
-    shift = snout + 0.5*thick + NOZZLE_OFFSET
+    shift = snout + 0.5*thick + RS_OFFSET
     
     d_x = shift * sin( radians(gantryangle) )
     d_y = -1.0 * shift * cos( radians(gantryangle) )
@@ -51,8 +64,8 @@ def get_translation( field, thick, gantryangle ):
 
 
 def get_props( field ):
-    """Return RangeShifter object with all properties for field
-    (i.e. IonBeamSequence[i])
+    """Return RangeShifter object with all relevant properties
+    
     """
     
     has_RS = hasattr( field.IonControlPointSequence[0], "RangeShifterSettingsSequence" )

--- a/gate-pbt/simulation/rangeshifter.py
+++ b/gate-pbt/simulation/rangeshifter.py
@@ -43,7 +43,7 @@ def get_translation( field, thick, gantryangle ):
     shift = snout + 0.5*thick + NOZZLE_OFFSET
     
     d_x = shift * sin( radians(gantryangle) )
-    d_y = shift * cos( radians(gantryangle) )
+    d_y = -1.0 * shift * cos( radians(gantryangle) )
     
     translation = [d_x, d_y, 0]
     return translation

--- a/gate-pbt/simulation/rangeshifter.py
+++ b/gate-pbt/simulation/rangeshifter.py
@@ -31,9 +31,11 @@ from math import sin, cos, radians
 
 
 # dist (mm) between rangeshifter distal face and nozzle exit
-RS_OFFSET = 18  
-# dictionary of rangeshifter thicknesses in use
-#RS_THICKNESS = {}
+##RS_OFFSET = 18  # just use IsocentreToRangeShifterDistance tag!
+
+# dictionary of rangeshifter WET to physical thicknesses in use (since
+# dicom file will only contain WET)
+RS_THICKNESS = { 57.0:50 }
 
 
 
@@ -45,15 +47,28 @@ class Rangeshifter:
         if translation is None: 
             translation = [0,0,0]
         self.translation = translation
-        self.offset = RS_OFFSET
+        ##self.offset = RS_OFFSET
 
 
 
-def get_translation( field, thick, gantryangle ):
+'''def get_translation( field, thick, gantryangle ):
     
     #Distance (mm) from isocentre to downstream side of snout
     snout = field.IonControlPointSequence[0].SnoutPosition  
     shift = snout + 0.5*thick + RS_OFFSET
+    
+    d_x = shift * sin( radians(gantryangle) )
+    d_y = -1.0 * shift * cos( radians(gantryangle) )
+    
+    translation = [d_x, d_y, 0]
+    return translation'''
+    
+
+    
+def get_translation( iso_to_rs, thick, gantryangle ):
+    """Get translation vector required to correctly shift RS in Gate"""
+    
+    shift = iso_to_rs + 0.5*thick
     
     d_x = shift * sin( radians(gantryangle) )
     d_y = -1.0 * shift * cos( radians(gantryangle) )
@@ -76,11 +91,13 @@ def get_props( field ):
     
     ##if has_RS or has_RS_2:       
     if has_RS:
-        # Get properties
-        #thick = field.RangeShifterSettingsSequence[0].RangeShifterWaterEquivalentThickness
-        thick = 50 #mm
-        gantryangle = field.IonControlPointSequence[0].GantryAngle
-        trans = get_translation(field, thick, gantryangle)
+
+        rsss =  field.IonControlPointSequence[0].RangeShifterSettingsSequence[0]    
+        thick = RS_THICKNESS[ rsss.RangeShifterWaterEquivalentThickness ]
+        gantryangle = field.IonControlPointSequence[0].GantryAngle       
+        iso_to_rs = rsss.IsocenterToRangeShifterDistance
+        trans = get_translation(iso_to_rs, thick, gantryangle)
+        ####trans = get_translation(field, thick, gantryangle)
         
         print("RS props: {},{},{}".format(gantryangle, trans, thick)   )
         

--- a/gate-pbt/simulation/rangeshifter.py
+++ b/gate-pbt/simulation/rangeshifter.py
@@ -19,19 +19,10 @@ from math import sin, cos, radians
 ######### TODO
 #
 # 1. Keep 0mm thickness RS in for all plans? Need to move it out of beam?
-# 2. Map WET from dicom to physical thickness
-# 3. Need exact RS dimensions
-# 4. Need RS material composition
-# 5. Need  offset RS offset from nozzle exit
-# 6.  field.RangeShifterSettingsSequence[0].RangeShifterWaterEquivalentThickness or field.RangeShifterSequence??
-#        field.NumberOfRangeShifters
+# 2. Need exact RS dimensions
 #
 #########
 
-
-
-# dist (mm) between rangeshifter distal face and nozzle exit
-##RS_OFFSET = 18  # just use IsocentreToRangeShifterDistance tag!
 
 # dictionary of rangeshifter WET to physical thicknesses in use (since
 # dicom file will only contain WET)
@@ -47,21 +38,6 @@ class Rangeshifter:
         if translation is None: 
             translation = [0,0,0]
         self.translation = translation
-        ##self.offset = RS_OFFSET
-
-
-
-'''def get_translation( field, thick, gantryangle ):
-    
-    #Distance (mm) from isocentre to downstream side of snout
-    snout = field.IonControlPointSequence[0].SnoutPosition  
-    shift = snout + 0.5*thick + RS_OFFSET
-    
-    d_x = shift * sin( radians(gantryangle) )
-    d_y = -1.0 * shift * cos( radians(gantryangle) )
-    
-    translation = [d_x, d_y, 0]
-    return translation'''
     
 
     
@@ -80,27 +56,20 @@ def get_translation( iso_to_rs, thick, gantryangle ):
 
 def get_props( field ):
     """Return RangeShifter object with all relevant properties
-    
     """
     
     has_RS = hasattr( field.IonControlPointSequence[0], "RangeShifterSettingsSequence" )
-    ##has_RS_2 = hasattr( field, "RangeShifterSequence" )
     
     # Default zero rangeshifter
     rs = Rangeshifter()
     
-    ##if has_RS or has_RS_2:       
     if has_RS:
-
         rsss =  field.IonControlPointSequence[0].RangeShifterSettingsSequence[0]    
         thick = RS_THICKNESS[ rsss.RangeShifterWaterEquivalentThickness ]
         gantryangle = field.IonControlPointSequence[0].GantryAngle       
         iso_to_rs = rsss.IsocenterToRangeShifterDistance
-        trans = get_translation(iso_to_rs, thick, gantryangle)
-        ####trans = get_translation(field, thick, gantryangle)
-        
-        print("RS props: {},{},{}".format(gantryangle, trans, thick)   )
-        
+        trans = get_translation(iso_to_rs, thick, gantryangle) 
+        ##print("RS props: {},{},{}".format(gantryangle, trans, thick)   )
         rs = Rangeshifter(rotation=gantryangle, translation=trans, thickness=thick)
         
     return rs

--- a/gate-pbt/simulation/rangeshifter.py
+++ b/gate-pbt/simulation/rangeshifter.py
@@ -22,7 +22,7 @@ from math import sin, cos, degrees, radians
 
 
 
-NOZZLE_OFFSET = 18.0  # mm
+NOZZLE_OFFSET = 0  # mm
 
 
 class Rangeshifter:
@@ -47,7 +47,7 @@ def get_translation( field, thick, gantryangle ):
     
     translation = [d_x, d_y, 0]
     return translation
-    s
+
 
 
 def get_props( field ):
@@ -65,7 +65,7 @@ def get_props( field ):
     if has_RS:
         # Get properties
         #thick = field.RangeShifterSettingsSequence[0].RangeShifterWaterEquivalentThickness
-        thick = 5.0
+        thick = 50 #mm
         gantryangle = field.IonControlPointSequence[0].GantryAngle
         trans = get_translation(field, thick, gantryangle)
         

--- a/gate-pbt/simulation/rangeshifter.py
+++ b/gate-pbt/simulation/rangeshifter.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu May  7 16:25:22 2020
+
+Methods related to positioning of rangeshifter
+
+@author: SCOURT01
+"""
+
+from math import sin, cos, degrees, radians
+
+######### TODO
+#
+# 1. Keep 0mm thickness RS in for all plans? Need to move it out of beam?
+# 2. Map WET from dicom to physical thickness
+# 3. Need exact RS dimensions
+# 4. Need RS material composition
+# 5. Need  offset RS offset from nozzle exit
+#
+#############
+
+
+
+NOZZLE_OFFSET = 18.0  # mm
+
+
+class Rangeshifter:
+    
+    def __init__(self, rotation=0, translation=None, thickness=0 ):
+        self.rotation = rot
+        self.thickness = thicknesss 
+        if translation is None: 
+            translation = [0,0,0]
+        self.translation = translation
+
+
+
+def get_translation( field, thick, gantryangle ):
+    
+    #Distance (mm) from isocentre to downstream side of snout
+    snout = field.SnoutPosition  
+    shift = snout + 0.5*thick + NOZZLE_OFFSET
+    
+    d_x = shift * sin( radians(gantryangle) )
+    d_y = shift * cos( radians(gantryangle) )
+    
+    translation = [d_x, d_y, 0]
+    return translation
+    
+
+
+def get_props( field ):
+    """Return RangeShifter object with all properties for field
+    (i.e. IonBeamSequence[i])
+    """
+    
+    has_RS = hasattr( field, "RangeShifterSettingsSequence" )
+    
+    # Default zero rangeshifter
+    rs = RangeShifter()
+    
+    if has_RS:       
+        # Get properties
+        thick = field.RangeShifterSettingsSequence[0].RangeShifterWaterEquivalentThickness
+        gantryangle = field.GantryAngle
+        trans = get_translation(field, thick, gantryangle)
+        
+        print("RS props: {},{},{}".format(gantryangle, trans, thick)   )
+        
+        rs = Rangeshifter(rotation=gantryangle, translation=trans, thickness=thick)
+        
+    return rs
+
+        

--- a/gate-pbt/simulation/roiutils.py
+++ b/gate-pbt/simulation/roiutils.py
@@ -18,10 +18,7 @@ other clinics as well).
 Authors: David Boersma and Pierre Granger
 """
 
-#from .bounding_box import *
-
 from boundingbox import *
-
 
 
 #from bounding_import bounding_box

--- a/gate-pbt/simulation/run.py
+++ b/gate-pbt/simulation/run.py
@@ -153,8 +153,9 @@ def main():
  
 
 
-    ct_unmod = os.path.join(sim_dir,"data","ct_orig.mhd")    
-    ct_air = os.path.join(sim_dir,"data","ct_air.mhd")
+    ct_unmod = os.path.join(sim_dir,"data","ct_orig.mhd")  ##path or name?
+    ct_for_simulation = "ct_air.mhd"
+    ct_air = os.path.join(sim_dir,"data",ct_for_simulation)
 
     
 
@@ -179,7 +180,7 @@ def main():
     
     # Generate all files required for simulation
     print("Generating simulation files")
-    generatefiles.generate_files(ct_files, plan_file, dose_files, TEMPLATE_MAC, TEMPLATE_SOURCE, ct_air, sim_dir)
+    generatefiles.generate_files(ct_files, plan_file, dose_files, TEMPLATE_MAC, TEMPLATE_SOURCE, ct_for_simulation, sim_dir)
     
     
     

--- a/gate-pbt/simulation/run.py
+++ b/gate-pbt/simulation/run.py
@@ -137,7 +137,7 @@ def main():
         sys.exit(0)
         
     DICOM_DIR = easygui.diropenbox()
-    #CT_DIR = os.path.join(DICOM_DIR,"ct")
+    CT_DIR = os.path.join(DICOM_DIR,"ct")
     TEMPLATE_MAC = os.path.join(path_to_templates,"TEMPLATE_simulateField.txt")
     TEMPLATE_SOURCE = os.path.join(path_to_templates,"TEMPLATE_SourceDescFile.txt")
    
@@ -161,7 +161,7 @@ def main():
 
     # Convert dicom series to mhd + raw
     print("Converting dcm CT files to mhd image")
-    imageconversion.dcm2mhd(os.path.join(DICOM_DIR,"ct"), ct_unmod)
+    imageconversion.dcm2mhd(CT_DIR, ct_unmod)
     ##imageconversion.dcm2mhd_gatetools(ct_files)
     
     


### PR DESCRIPTION
Added automated rangeshifter functionality. Things still to do:

1. Get exact dimensions, density and chemical composition of the (Lexan?) polycarbonate.
2. Decide what to do for fields with no rangeshifter: (i) just set its thickness to 0, (ii) translate and rotate out of beam's path, (iii) just use a separate mac template file for fields with/without rangeshifters.


